### PR TITLE
Rails 6 compatibility - this time for real

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Installation
 ------------
 
-`$ gem install 'tremendous_ruby'`
+`$ gem install tremendous_ruby`
 
 or, add to your Gemfile
 
@@ -28,7 +28,6 @@ client = Tremendous::Rest.new(
   "https://testflight.tremendous.com/api/v2/"
 )
 
-
 #
 # Generate an order.
 #
@@ -43,7 +42,6 @@ campaign_id = campaigns.first[:id]
 # The funding source you select is how you are charged for the order.
 # In this example, we use the prefunded balance funding source
 funding_source_id = client.funding_sources.list.find { |f| f[:method] == "balance" }[:id]
-
 
 # Optionally pass a unique external_id for each order create call
 # to guarantee that your order is idempotent and not executed multiple times.
@@ -74,11 +72,12 @@ order_data = {
 # Submit the order.
 order = client.orders.create!(order_data)
 
-# Retrieve the reward
+# Retrieve the reward.
 client.rewards.show(order[:rewards].first[:id])
 ```
 
 Contributing
 ------------
+
 The gem is maintained by Tremendous engineers, but all are welcome to contribute.
 Feel free to open an issue, submit a PR, or post a question.

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,7 @@
-require 'rake/testtask'
+require 'rubygems'
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
-Rake::TestTask.new do |t|
-  t.libs << 'test'
-end
+RSpec::Core::RakeTask.new(:spec)
 
-desc "Run tests"
-task :default => :test
+task default: :spec

--- a/lib/tremendous/campaign.rb
+++ b/lib/tremendous/campaign.rb
@@ -2,7 +2,7 @@ module Tremendous
   module Campaign
 
     def self.included(base)
-      base.send :include, InstanceMethods
+      base.include InstanceMethods
     end
 
     module InstanceMethods
@@ -18,7 +18,6 @@ module Tremendous
         get(
           'campaigns',
           query: filters,
-          format: 'json'
         )[:campaigns]
       end
 

--- a/lib/tremendous/funding_source.rb
+++ b/lib/tremendous/funding_source.rb
@@ -1,9 +1,8 @@
 module Tremendous
   module FundingSource
-    include Request
 
     def self.included(base)
-      base.send :include, InstanceMethods
+      base.include InstanceMethods
     end
 
     module InstanceMethods
@@ -19,7 +18,6 @@ module Tremendous
         get(
           'funding_sources',
           query: filters,
-          format: 'json'
         )[:funding_sources]
       end
 

--- a/lib/tremendous/invoice.rb
+++ b/lib/tremendous/invoice.rb
@@ -2,7 +2,7 @@ module Tremendous
   module Invoice
 
     def self.included(base)
-      base.send :include, InstanceMethods
+      base.include InstanceMethods
     end
 
     module InstanceMethods
@@ -28,7 +28,6 @@ module Tremendous
         get(
           'invoices',
           query: filters,
-          format: 'json'
         )[:invoices]
       end
 

--- a/lib/tremendous/member.rb
+++ b/lib/tremendous/member.rb
@@ -2,7 +2,7 @@ module Tremendous
   module Member
 
     def self.included(base)
-      base.send :include, InstanceMethods
+      base.include InstanceMethods
     end
 
     module InstanceMethods
@@ -26,7 +26,6 @@ module Tremendous
         get(
           "members",
           query: filters,
-          format: 'json'
         )[:members]
       end
 

--- a/lib/tremendous/order.rb
+++ b/lib/tremendous/order.rb
@@ -2,7 +2,7 @@ module Tremendous
   module Order
 
     def self.included(base)
-      base.send :include, InstanceMethods
+      base.include InstanceMethods
     end
 
     module InstanceMethods
@@ -26,7 +26,6 @@ module Tremendous
         get(
           'orders',
           query: filters,
-          format: 'json'
         )[:orders]
       end
 

--- a/lib/tremendous/organization.rb
+++ b/lib/tremendous/organization.rb
@@ -2,7 +2,7 @@ module Tremendous
   module Organization
 
     def self.included(base)
-      base.send :include, InstanceMethods
+      base.include InstanceMethods
     end
 
     module InstanceMethods

--- a/lib/tremendous/product.rb
+++ b/lib/tremendous/product.rb
@@ -1,7 +1,7 @@
 module Tremendous
   module Product
     def self.included(base)
-      base.send :include, InstanceMethods
+      base.include InstanceMethods
     end
 
     module InstanceMethods
@@ -17,7 +17,6 @@ module Tremendous
         get(
           'products',
           query: filters,
-          format: 'json'
         )[:products]
       end
 

--- a/lib/tremendous/request.rb
+++ b/lib/tremendous/request.rb
@@ -6,13 +6,7 @@ module Tremendous
       @uri = uri
     end
 
-    def access_token
-      @access_token
-    end
-
-    def uri
-      @uri
-    end
+    attr_reader :access_token, :uri
 
     def get(path, data={}, *opts)
       handle_response(_execute(:get, url(path), data, *opts))
@@ -31,6 +25,7 @@ module Tremendous
     end
 
     def _execute(method, url, data={}, *opts)
+      data[:format] = :json
       data[:headers] = {
         'authorization' => "Bearer #{@access_token}"
       }.merge(data.class == Hash ? data[:headers] || {} : {})

--- a/lib/tremendous/reward.rb
+++ b/lib/tremendous/reward.rb
@@ -2,7 +2,7 @@ module Tremendous
   module Reward
 
     def self.included(base)
-      base.send :include, InstanceMethods
+      base.include InstanceMethods
     end
 
     module InstanceMethods
@@ -18,7 +18,6 @@ module Tremendous
         get(
           'rewards',
           query: filters,
-          format: 'json'
         )[:rewards]
       end
 

--- a/lib/tremendous/webhook.rb
+++ b/lib/tremendous/webhook.rb
@@ -2,7 +2,7 @@ module Tremendous
   module Webhook
 
     def self.included(base)
-      base.send :include, InstanceMethods
+      base.include InstanceMethods
     end
 
     module InstanceMethods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require 'tremendous'
+
+require 'bundler'
+Bundler.require :test
+
+require 'webmock'
+require 'webmock/rspec/matchers'
+WebMock.enable!
+WebMock.disable_net_connect!
+
+RSpec.configure do |config|
+  config.include WebMock::API
+  config.include WebMock::Matchers
+end

--- a/spec/tremendous/rest_spec.rb
+++ b/spec/tremendous/rest_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe Tremendous::Rest do
+  let(:client) { described_class.new(access_token, endpoint) }
+  let(:access_token) { 'your-access-token' }
+  let(:endpoint) { 'https://www.tremendous.com/api/v2/' }
+
+  shared_examples 'handles error' do
+    let(:response) { {status: 500, body: {errors: ['Internal Server Error']}.to_json} }
+
+    specify do
+      expect(&subject).to raise_error(Tremendous::Error, 'Code: 500; Data: ["Internal Server Error"]')
+    end
+  end
+
+  describe '#orders' do
+    let(:order_data) do
+      {
+        'id' => 'QABSTARTSFSIO',
+        'external_id' => 'id-from-client',
+        'payment' => {'subtotal' => 10, 'total' => 10, 'fees' => 0},
+        'rewards' => [{'id' => 'DDABSUKSFSTY'}]
+      }
+    end
+
+    describe '#list' do
+      subject {->{ client.orders.list }}
+
+      before do
+        stub_request(:get, "#{endpoint}orders").
+          with(headers: {authorization: "Bearer #{access_token}"}).
+          to_return(response)
+      end
+      let(:response) { {status: 200, body: {orders: [order_data]}.to_json} }
+
+      it 'returns list of orders' do
+        expect(subject.call).to eq [order_data]
+      end
+
+      it_behaves_like 'handles error'
+    end
+
+    describe '#create!' do
+      subject {->{ client.orders.create!(order_data) }}
+
+      before do
+        stub_request(:post, "#{endpoint}orders").
+          with(headers: {authorization: "Bearer #{access_token}", content_type: 'application/json'}).
+          to_return(response)
+      end
+      let(:response) { {status: 200, body: {order: order_data}.to_json} }
+
+      it 'returns created order' do
+        expect(subject.call).to eq order_data
+      end
+
+      it_behaves_like 'handles error'
+    end
+  end
+end

--- a/spec/tremendous_spec.rb
+++ b/spec/tremendous_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Tremendous do
+  it 'has a version number' do
+    expect(Tremendous::VERSION).not_to be nil
+  end
+end

--- a/tremendous.gemspec
+++ b/tremendous.gemspec
@@ -4,23 +4,22 @@ require File.expand_path('../lib/tremendous/version', __FILE__)
 Gem::Specification.new do |spec|
   spec.name          = 'tremendous_ruby'
   spec.version       = Tremendous::VERSION
-  spec.summary       = "Rewards and Incentives as a service"
-  spec.summary       = 'Tremendous API SDK'
   spec.licenses      = ['MIT']
   spec.homepage      = 'https://github.com/GiftRocket/tremendous-ruby'
   spec.summary       = 'Tremendous Ruby API SDK'
   spec.authors       = ['Tremendous Developers']
   spec.email         = ['developers@tremendous.com']
   spec.files         = Dir['lib/**/*.rb']
+  spec.metadata      = {
+    'documentation_uri' => 'https://www.tremendous.com/docs',
+    'source_code_uri'   => spec.homepage
+  }
 
-  spec.add_runtime_dependency 'activesupport', '>= 3.2', '<= 6.0.0.rc1'
+  spec.add_runtime_dependency 'activesupport', '>= 3.2', '< 6.1'
   spec.add_runtime_dependency 'httparty', '>= 0.14.0'
   spec.add_runtime_dependency 'jwt', '>= 1.5.0'
 
-  spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'mocha', '~> 1.1'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'simplecov', '~> 0.10'
-  spec.add_development_dependency 'webmock', '~> 1.20'
-
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec', '>= 3.5.0'
+  spec.add_development_dependency 'webmock', '>= 3'
 end

--- a/tremendous.gemspec
+++ b/tremendous.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     'source_code_uri'   => spec.homepage
   }
 
-  spec.add_runtime_dependency 'activesupport', '>= 3.2', '< 6.1'
+  spec.add_runtime_dependency 'activesupport', '>= 3.2', '< 6.2'
   spec.add_runtime_dependency 'httparty', '>= 0.14.0'
   spec.add_runtime_dependency 'jwt', '>= 1.5.0'
 


### PR DESCRIPTION
Hi. The change from https://github.com/GiftRocket/tremendous-ruby/commit/b2355c63d8be85a223f043356bc9e5aae091db5a has broken the error handling – which was not detected since the gem has zero test coverage.

### Bug description
This gem passes `format: 'json'` to `HTTParty` while it should pass it as a symbol: `format: :json`.
``` ruby
irb(main):001:0> require 'httparty'; HTTParty::Parser.supports_format?('json')
=> false
irb(main):002:0> require 'httparty'; HTTParty::Parser.supports_format?(:json)
=> true
```
You can see the list of supported formats here: https://github.com/jnunemaker/httparty/blob/54b7949b91b045680ea4cd40a91d2bad7165a295/lib/httparty/parser.rb#L40-L54
Since HTTParty does not support `"json"`, it does not parse json-encoded error responses and instead of a `Tremendous::Error` we get unhandled `NoMethodError`:
> tremendous-ruby/lib/tremendous/error.rb:10:in 'server_response': undefined method 'with_indifferent_access' for "{\"errors\":[\"Internal Server Error\"]}":String (NoMethodError)

### Summary of changes
* Changed `format: 'json'` to `format: :json`
* Configured RSpec and added basic specs
* Changed `base.send(:include, InstanceMethods)` to `base.include InstanceMethods`. `Module.include` is a public method since Ruby 2.1.
* Cleaned up the README
* Updated `gemspec`: updated dependencies, added `source_code_uri`, removed duplicate `summary` lines