### PR TITLE
Bump ActiveSupport version cap to 7.1

### DIFF
--- a/tremendous.gemspec
+++ b/tremendous.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     'source_code_uri'   => spec.homepage
   }
 
-  spec.add_runtime_dependency 'activesupport', '>= 3.2', '< 7.1'
+  spec.add_runtime_dependency 'activesupport', '>= 3.2'
   spec.add_runtime_dependency 'httparty', '>= 0.18.0'
   spec.add_runtime_dependency 'jwt', '>= 1.5.0'
 

--- a/tremendous.gemspec
+++ b/tremendous.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     'source_code_uri'   => spec.homepage
   }
 
-  spec.add_runtime_dependency 'activesupport', '>= 3.2', '< 6.2'
+  spec.add_runtime_dependency 'activesupport', '>= 3.2', '< 7.1'
   spec.add_runtime_dependency 'httparty', '>= 0.18.0'
   spec.add_runtime_dependency 'jwt', '>= 1.5.0'
 


### PR DESCRIPTION
To use the gem with Rails 7, we need to bump the version cap for `activesupport`. Since we're only using `with_indifferent_access` from it and there are no recent breaking changes to that extension, this version bump should be enough.

Ran `rake spec` (on ruby 2.7 and 3.1) with no issues locally. (It also works fine on a simple local Rails 7 project.)