### PR TITLE
Bugfix - add error handling for non json error responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .byebug_history
 *.gem
 .ruby-version
+/vendor

--- a/lib/tremendous/error.rb
+++ b/lib/tremendous/error.rb
@@ -1,6 +1,72 @@
 module Tremendous
   class Error < StandardError
 
+    HTTP_STATUS_CODES = {
+      100 => 'Continue',
+      101 => 'Switching Protocols',
+      102 => 'Processing',
+      103 => 'Early Hints',
+      200 => 'OK',
+      201 => 'Created',
+      202 => 'Accepted',
+      203 => 'Non-Authoritative Information',
+      204 => 'No Content',
+      205 => 'Reset Content',
+      206 => 'Partial Content',
+      207 => 'Multi-Status',
+      208 => 'Already Reported',
+      226 => 'IM Used',
+      300 => 'Multiple Choices',
+      301 => 'Moved Permanently',
+      302 => 'Found',
+      303 => 'See Other',
+      304 => 'Not Modified',
+      305 => 'Use Proxy',
+      306 => '(Unused)',
+      307 => 'Temporary Redirect',
+      308 => 'Permanent Redirect',
+      400 => 'Bad Request',
+      401 => 'Unauthorized',
+      402 => 'Payment Required',
+      403 => 'Forbidden',
+      404 => 'Not Found',
+      405 => 'Method Not Allowed',
+      406 => 'Not Acceptable',
+      407 => 'Proxy Authentication Required',
+      408 => 'Request Timeout',
+      409 => 'Conflict',
+      410 => 'Gone',
+      411 => 'Length Required',
+      412 => 'Precondition Failed',
+      413 => 'Payload Too Large',
+      414 => 'URI Too Long',
+      415 => 'Unsupported Media Type',
+      416 => 'Range Not Satisfiable',
+      417 => 'Expectation Failed',
+      421 => 'Misdirected Request',
+      422 => 'Unprocessable Entity',
+      423 => 'Locked',
+      424 => 'Failed Dependency',
+      425 => 'Too Early',
+      426 => 'Upgrade Required',
+      428 => 'Precondition Required',
+      429 => 'Too Many Requests',
+      431 => 'Request Header Fields Too Large',
+      451 => 'Unavailable for Legal Reasons',
+      500 => 'Internal Server Error',
+      501 => 'Not Implemented',
+      502 => 'Bad Gateway',
+      503 => 'Service Unavailable',
+      504 => 'Gateway Timeout',
+      505 => 'HTTP Version Not Supported',
+      506 => 'Variant Also Negotiates',
+      507 => 'Insufficient Storage',
+      508 => 'Loop Detected',
+      509 => 'Bandwidth Limit Exceeded',
+      510 => 'Not Extended',
+      511 => 'Network Authentication Required'
+    }
+
     def initialize(response)
       @response = response
       super
@@ -13,7 +79,7 @@ module Tremendous
     def parsed_response
       @response.parsed_response.with_indifferent_access
     rescue StandardError
-      { errors: ['Internal Server Error'] }
+      { errors: [ HTTP_STATUS_CODES[@response.code] ] }
     end
 
     def message

--- a/lib/tremendous/error.rb
+++ b/lib/tremendous/error.rb
@@ -7,7 +7,13 @@ module Tremendous
     end
 
     def server_response
-      @server_response ||= @response.parsed_response.with_indifferent_access
+      @server_response ||= parsed_response
+    end
+
+    def parsed_response
+      @response.parsed_response.with_indifferent_access
+    rescue StandardError
+      { errors: ['Internal Server Error'] }
     end
 
     def message

--- a/spec/tremendous/rest_spec.rb
+++ b/spec/tremendous/rest_spec.rb
@@ -13,6 +13,14 @@ describe Tremendous::Rest do
     end
   end
 
+  shared_examples 'handles non-json formatted error response' do
+    let(:response) { {status: 500, body: '<html><head></head><body></body></html>'} }
+
+    specify do
+      expect(&subject).to raise_error(Tremendous::Error, 'Code: 500; Data: ["Internal Server Error"]')
+    end
+  end
+
   describe '#orders' do
     let(:order_data) do
       {
@@ -21,6 +29,10 @@ describe Tremendous::Rest do
         'payment' => {'subtotal' => 10, 'total' => 10, 'fees' => 0},
         'rewards' => [{'id' => 'DDABSUKSFSTY'}]
       }
+    end
+
+    let(:html_response) do
+      '<html><head></head><body></body></html>'
     end
 
     describe '#list' do
@@ -38,6 +50,7 @@ describe Tremendous::Rest do
       end
 
       it_behaves_like 'handles error'
+      it_behaves_like 'handles non-json formatted error response'
     end
 
     describe '#create!' do
@@ -55,6 +68,7 @@ describe Tremendous::Rest do
       end
 
       it_behaves_like 'handles error'
+      it_behaves_like 'handles non-json formatted error response'
     end
   end
 end


### PR DESCRIPTION
As reported in https://github.com/tremendous-rewards/tremendous-ruby/issues/11, we sometimes receive html formatted error responses from API requests to Tremendous. We can rescue from the initial parsing error, but when generating the exception message in `Tremendous::Error#server_response`, `@response.parsed_response` is invoked again, which attempts to parse the html as JSON, raising another error.

We can workaround this issue in our codebase, but perhaps this gem should handle the error.

Am I missing anything here such as support for specific ruby versions?

Thanks