### PR TITLE
s/www/api

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ require 'tremendous'
 access_token = "[YOUR SANDBOX ACCESS TOKEN]"
 
 # URL
-# (production: use "https://www.tremendous.com/api/v2/")
+# (production: use "https://api.tremendous.com/api/v2/")
 url = "https://testflight.tremendous.com/api/v2/"
 
 client = Tremendous::Rest.new(access_token, url)

--- a/spec/tremendous/rest_spec.rb
+++ b/spec/tremendous/rest_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Tremendous::Rest do
   let(:client) { described_class.new(access_token, endpoint) }
   let(:access_token) { 'your-access-token' }
-  let(:endpoint) { 'https://www.tremendous.com/api/v2/' }
+  let(:endpoint) { 'https://api.tremendous.com/api/v2/' }
 
   shared_examples 'handles error' do
     let(:response) { {status: 500, body: {errors: ['Internal Server Error']}.to_json} }


### PR DESCRIPTION
We serving our API under the `api` subdomain now, so just updating the example we show here
