### PR TITLE
Sets custom user Agent: Tremendous Ruby vX.Y.Z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+### 4.3.5 (unreleased)
+
+* Sets user-agent on each request
+
+### 4.3.4 2023-09-19
+
+* Adds `Tremendous::Reward#generate_link` endpoint
+* Fixes API host (changed internally)
+
+### 4.3.3 2023-02-24
+
+* Fixes `Tremendous::Error#to_s`
+
+### 4.3.2 2023-02-23
+
+* Fixes handling of non-JSON error responses from the API
+
 ### 4.3.1 - 2022-07-13
 
 * Relaxes dependency constraints on ActiveSupport version (removes upper cap of version)

--- a/lib/tremendous/request.rb
+++ b/lib/tremendous/request.rb
@@ -27,7 +27,9 @@ module Tremendous
     def _execute(method, url, data={}, *opts)
       data[:format] = :json
       data[:headers] = {
-        'authorization' => "Bearer #{@access_token}"
+        'authorization' => "Bearer #{@access_token}",
+        'user-agent' => "Tremendous Ruby v#{Tremendous::VERSION}",
+        'content-type' => "application/json"
       }.merge(data.class == Hash ? data[:headers] || {} : {})
 
       HTTParty.send(method, url, data, *opts)

--- a/spec/tremendous/rest_spec.rb
+++ b/spec/tremendous/rest_spec.rb
@@ -5,6 +5,14 @@ describe Tremendous::Rest do
   let(:access_token) { 'your-access-token' }
   let(:endpoint) { 'https://api.tremendous.com/api/v2/' }
 
+  let(:headers) do
+    {
+      authorization: "Bearer #{access_token}",
+      content_type: "application/json",
+      user_agent:  "Tremendous Ruby v#{Tremendous::VERSION}",
+    }
+  end
+
   shared_examples 'handles error' do
     let(:response) { {status: 500, body: {errors: ['Internal Server Error']}.to_json} }
 
@@ -39,9 +47,7 @@ describe Tremendous::Rest do
       subject {->{ client.orders.list }}
 
       before do
-        stub_request(:get, "#{endpoint}orders").
-          with(headers: {authorization: "Bearer #{access_token}"}).
-          to_return(response)
+        stub_request(:get, "#{endpoint}orders").with(headers:).to_return(response)
       end
       let(:response) { {status: 200, body: {orders: [order_data]}.to_json} }
 
@@ -57,9 +63,7 @@ describe Tremendous::Rest do
       subject {->{ client.orders.create!(order_data) }}
 
       before do
-        stub_request(:post, "#{endpoint}orders").
-          with(headers: {authorization: "Bearer #{access_token}", content_type: 'application/json'}).
-          to_return(response)
+        stub_request(:post, "#{endpoint}orders").with(headers:).to_return(response)
       end
       let(:response) { {status: 200, body: {order: order_data}.to_json} }
 


### PR DESCRIPTION
All requests issued from the gem will now have their user-agent set to: `"Tremendous Ruby v#{Tremendous::VERSION}"`